### PR TITLE
Update InfCode official website URL

### DIFF
--- a/evaluation/java/verified/20260131_InfCode_GPT-5.2/metadata.yaml
+++ b/evaluation/java/verified/20260131_InfCode_GPT-5.2/metadata.yaml
@@ -1,5 +1,5 @@
 name: InfCode + GPT5.2
 orgIcon: https://raw.githubusercontent.com/Tokfinity/InfCode/main/figures/Tokfinity.png
 oss: true
-site: 'www.tokfinity.com'
+site: https://www.tokfinity.com/infcode
 verified: false


### PR DESCRIPTION
Hi Maintainers,

Thanks again for all your hard work on managing the benchmark and reviewing submissions!

We have corrected the invalid site URL in the `java/verified/20260131_InfCode_GPT-5.2/metadata.yaml` file.

This change ensures the leaderboard will point to the correct and most up-to-date source for our tool.

Thanks for making this update!